### PR TITLE
fix: use plural channel_ids in query_incidents/query_changes

### DIFF
--- a/pkg/flashduty/changes.go
+++ b/pkg/flashduty/changes.go
@@ -23,7 +23,7 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 				ReadOnlyHint: ToBoolPtr(true),
 			}),
 			mcp.WithString("change_ids", mcp.Description("Comma-separated change IDs for direct lookup.")),
-			mcp.WithNumber("channel_id", mcp.Description("Filter by collaboration space ID.")),
+			mcp.WithString("channel_ids", mcp.Description("Filter by collaboration space IDs. Comma-separated for multiple.")),
 			mcp.WithNumber("start_time", mcp.Description("Query start time in Unix timestamp (seconds). Must be < end_time. Max range: 31 days. Defaults to 1 hour ago.")),
 			mcp.WithNumber("end_time", mcp.Description("Query end time in Unix timestamp (seconds). Defaults to now.")),
 			mcp.WithString("type", mcp.Description("Filter by change type.")),
@@ -35,7 +35,8 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 			}
 
 			changeIdsStr, _ := OptionalParam[string](request, "change_ids")
-			channelID, _ := OptionalInt(request, "channel_id")
+			channelIdsStr, _ := OptionalParam[string](request, "channel_ids")
+			filterChannelIDs := parseCommaSeparatedInts(channelIdsStr)
 			startTime, _ := OptionalInt(request, "start_time")
 			endTime, _ := OptionalInt(request, "end_time")
 			changeType, _ := OptionalParam[string](request, "type")
@@ -54,8 +55,8 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 				changeIDs := parseCommaSeparatedStrings(changeIdsStr)
 				requestBody["change_ids"] = changeIDs
 			}
-			if channelID > 0 {
-				requestBody["channel_id"] = channelID
+			if len(filterChannelIDs) > 0 {
+				requestBody["channel_ids"] = filterChannelIDs
 			}
 			if startTime > 0 {
 				requestBody["start_time"] = startTime

--- a/pkg/flashduty/incidents.go
+++ b/pkg/flashduty/incidents.go
@@ -30,7 +30,7 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 			mcp.WithString("incident_ids", mcp.Description("Comma-separated incident IDs for direct lookup. If provided, other filters are ignored.")),
 			mcp.WithString("progress", mcp.Description("Filter by status. Valid values: Triggered, Processing, Closed. Comma-separated for multiple."), mcp.Enum("Triggered", "Processing", "Closed", "Triggered,Processing", "Processing,Closed", "Triggered,Closed", "Triggered,Processing,Closed")),
 			mcp.WithString("severity", mcp.Description("Filter by severity level. Valid values: Info, Warning, Critical."), mcp.Enum("Info", "Warning", "Critical")),
-			mcp.WithNumber("channel_id", mcp.Description("Filter by collaboration space ID.")),
+			mcp.WithString("channel_ids", mcp.Description("Filter by collaboration space IDs. Comma-separated for multiple.")),
 			mcp.WithNumber("start_time", mcp.Description("Query start time in Unix timestamp (seconds). Required if no incident_ids. Must be < end_time. Max range: 31 days.")),
 			mcp.WithNumber("end_time", mcp.Description("Query end time in Unix timestamp (seconds). Required if no incident_ids. Must be within data retention period.")),
 			mcp.WithString("title", mcp.Description("Keyword search in incident title.")),
@@ -46,7 +46,8 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 			incidentIdsStr, _ := OptionalParam[string](request, "incident_ids")
 			progress, _ := OptionalParam[string](request, "progress")
 			severity, _ := OptionalParam[string](request, "severity")
-			channelID, _ := OptionalInt(request, "channel_id")
+			channelIdsStr, _ := OptionalParam[string](request, "channel_ids")
+			channelIDs := parseCommaSeparatedInts(channelIdsStr)
 			startTime, _ := OptionalInt(request, "start_time")
 			endTime, _ := OptionalInt(request, "end_time")
 			title, _ := OptionalParam[string](request, "title")
@@ -75,7 +76,7 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 				if startTime == 0 || endTime == 0 {
 					return mcp.NewToolResultError("Both start_time and end_time are required for time-based queries"), nil
 				}
-				rawIncidents, err = client.fetchIncidentsByFilters(ctx, progress, severity, channelID, startTime, endTime, title, limit)
+				rawIncidents, err = client.fetchIncidentsByFilters(ctx, progress, severity, channelIDs, startTime, endTime, title, limit)
 			}
 
 			if err != nil {
@@ -312,7 +313,7 @@ func (c *Client) fetchIncidentsByIDs(ctx context.Context, incidentIDs []string) 
 }
 
 // fetchIncidentsByFilters fetches incidents by filters
-func (c *Client) fetchIncidentsByFilters(ctx context.Context, progress, severity string, channelID int, startTime, endTime int, title string, limit int) ([]RawIncident, error) {
+func (c *Client) fetchIncidentsByFilters(ctx context.Context, progress, severity string, channelIDs []int, startTime, endTime int, title string, limit int) ([]RawIncident, error) {
 	requestBody := map[string]interface{}{
 		"p":          1,
 		"limit":      limit,
@@ -326,8 +327,8 @@ func (c *Client) fetchIncidentsByFilters(ctx context.Context, progress, severity
 	if severity != "" {
 		requestBody["incident_severity"] = severity
 	}
-	if channelID > 0 {
-		requestBody["channel_id"] = channelID
+	if len(channelIDs) > 0 {
+		requestBody["channel_ids"] = channelIDs
 	}
 	if title != "" {
 		requestBody["title"] = title


### PR DESCRIPTION
## Summary
- `query_incidents` and `query_changes` sent `channel_id` (singular `int`) to the backend, but `/incident/list` and `/change/list` expect `channel_ids` (`[]int64`). The singular field was silently dropped, leaking results from every channel.
- Renames the MCP tool parameter `channel_id` → `channel_ids` (comma-separated string), parsed via the existing `parseCommaSeparatedInts` helper.
- Bonus: now supports filtering by multiple channels in one call.

## Root cause
Backend input structs:
- `fc-event/cmd/server/controller/incident/info.go:384` — `ChannelIDs []int64 \`json:"channel_ids"\``
- `fc-event/cmd/server/controller/change/info.go:27` — `ChannelIDs []int64 \`json:"channel_ids"\``

Our MCP request body was `{"channel_id": N}`, which the backend silently ignored.

## Breaking change
Existing callers passing `channel_id: <n>` must switch to `channel_ids: "<n>"`. Without the switch, they continue to get unfiltered results (same bug as before the fix — no regression, but the call won't start filtering either).

## Test plan
- [ ] Call `query_incidents` with `channel_ids: "<single-id>"` — verify only incidents from that channel are returned.
- [ ] Call `query_incidents` with `channel_ids: "<id1>,<id2>"` — verify incidents from both channels.
- [ ] Call `query_incidents` with no `channel_ids` — verify no regression (all-channel results).
- [ ] Repeat the three cases for `query_changes`.
- [ ] Confirm the outbound HTTP body in logs contains `"channel_ids":[...]` (plural, array), not `"channel_id":N`.