### PR TITLE
fix: use 'query' field for name search in query_members/query_teams

### DIFF
--- a/pkg/flashduty/users.go
+++ b/pkg/flashduty/users.go
@@ -70,7 +70,7 @@ func QueryMembers(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 				"limit": defaultUsersQueryLimit,
 			}
 			if name != "" {
-				requestBody["member_name"] = name
+				requestBody["query"] = name
 			}
 			if email != "" {
 				requestBody["email"] = email
@@ -167,7 +167,7 @@ func QueryTeams(getClient GetFlashdutyClientFn, t translations.TranslationHelper
 				"limit": defaultUsersQueryLimit,
 			}
 			if name != "" {
-				requestBody["team_name"] = name
+				requestBody["query"] = name
 			}
 
 			resp, err := client.makeRequest(ctx, "POST", "/team/list", requestBody)


### PR DESCRIPTION
## Summary
- Backend `/member/list` and `/team/list` declare the search keyword as `query` (`fc-pgy/cmd/server/controller/member/member.go:38-45`, `fc-pgy/cmd/server/controller/team/team.go:311-318`), but the MCP server was sending `member_name` / `team_name`.
- The unknown fields were silently dropped → `query_members {name: "alice"}` and `query_teams {name: "ops"}` returned **all** members/teams instead of fuzzy-matched results.
- Same class of silent-mismatch bug as #43.

## Root cause
Backend structs:
```go
// member.go
type memberListInput struct {
    ...
    Query string `json:"query"`
}

// team.go
type listTeamInput struct {
    ...
    Query string `json:"query"`
}
```

## Change
Wire-only — change request body keys `member_name`/`team_name` → `query`. The MCP-side `name` parameter, tool descriptions, and any other public-facing surface are unchanged, so this is **not** a breaking change for callers.

## Test plan
- [ ] `go build ./...` — passes locally.
- [ ] `query_members {name: "<known-substring>"}` returns only matches (not the full list). Confirm outbound body in logs contains `"query":"..."`, not `"member_name":"..."`.
- [ ] `query_teams {name: "<known-substring>"}` — same check against `/team/list`.
- [ ] `query_members {person_ids: "..."}` regression: ID-direct path still works (it bypasses `/member/list`).

## Related
Surfaced by the audit captured in `TEST_PLAN_param_audit.md` (added in #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)