### PR TITLE
feat(alert-preview): surface integration_type/integration_name

### DIFF
--- a/pkg/flashduty/enrichment.go
+++ b/pkg/flashduty/enrichment.go
@@ -77,12 +77,14 @@ func (c *Client) fetchIncidentAlerts(ctx context.Context, incidentID string, lim
 		Data  *struct {
 			Total int `json:"total"`
 			Items []struct {
-				AlertID     string            `json:"alert_id"`
-				Title       string            `json:"title"`
-				Severity    string            `json:"severity"`
-				Status      string            `json:"status"`
-				TriggerTime int64             `json:"trigger_time"`
-				Labels      map[string]string `json:"labels,omitempty"`
+				AlertID        string            `json:"alert_id"`
+				Title          string            `json:"title"`
+				Severity       string            `json:"severity"`
+				Status         string            `json:"status"`
+				TriggerTime    int64             `json:"trigger_time"`
+				DataSourceType string            `json:"data_source_type,omitempty"`
+				DataSourceName string            `json:"data_source_name,omitempty"`
+				Labels         map[string]string `json:"labels,omitempty"`
 			} `json:"items"`
 		} `json:"data,omitempty"`
 	}
@@ -100,12 +102,14 @@ func (c *Client) fetchIncidentAlerts(ctx context.Context, incidentID string, lim
 	alerts := make([]AlertPreview, 0, len(result.Data.Items))
 	for _, item := range result.Data.Items {
 		alerts = append(alerts, AlertPreview{
-			AlertID:   item.AlertID,
-			Title:     item.Title,
-			Severity:  item.Severity,
-			Status:    item.Status,
-			StartTime: item.TriggerTime,
-			Labels:    item.Labels,
+			AlertID:        item.AlertID,
+			Title:          item.Title,
+			Severity:       item.Severity,
+			Status:         item.Status,
+			StartTime:      item.TriggerTime,
+			DataSourceType: item.DataSourceType,
+			DataSourceName: item.DataSourceName,
+			Labels:         item.Labels,
 		})
 	}
 	return alerts, result.Data.Total, nil

--- a/pkg/flashduty/enrichment.go
+++ b/pkg/flashduty/enrichment.go
@@ -77,14 +77,14 @@ func (c *Client) fetchIncidentAlerts(ctx context.Context, incidentID string, lim
 		Data  *struct {
 			Total int `json:"total"`
 			Items []struct {
-				AlertID        string            `json:"alert_id"`
-				Title          string            `json:"title"`
-				Severity       string            `json:"severity"`
-				Status         string            `json:"status"`
-				TriggerTime    int64             `json:"trigger_time"`
+				AlertID         string            `json:"alert_id"`
+				Title           string            `json:"title"`
+				Severity        string            `json:"severity"`
+				Status          string            `json:"status"`
+				TriggerTime     int64             `json:"trigger_time"`
 				IntegrationType string            `json:"integration_type,omitempty"`
 				IntegrationName string            `json:"integration_name,omitempty"`
-				Labels         map[string]string `json:"labels,omitempty"`
+				Labels          map[string]string `json:"labels,omitempty"`
 			} `json:"items"`
 		} `json:"data,omitempty"`
 	}
@@ -102,14 +102,14 @@ func (c *Client) fetchIncidentAlerts(ctx context.Context, incidentID string, lim
 	alerts := make([]AlertPreview, 0, len(result.Data.Items))
 	for _, item := range result.Data.Items {
 		alerts = append(alerts, AlertPreview{
-			AlertID:        item.AlertID,
-			Title:          item.Title,
-			Severity:       item.Severity,
-			Status:         item.Status,
-			StartTime:      item.TriggerTime,
+			AlertID:         item.AlertID,
+			Title:           item.Title,
+			Severity:        item.Severity,
+			Status:          item.Status,
+			StartTime:       item.TriggerTime,
 			IntegrationType: item.IntegrationType,
 			IntegrationName: item.IntegrationName,
-			Labels:         item.Labels,
+			Labels:          item.Labels,
 		})
 	}
 	return alerts, result.Data.Total, nil

--- a/pkg/flashduty/enrichment.go
+++ b/pkg/flashduty/enrichment.go
@@ -82,8 +82,8 @@ func (c *Client) fetchIncidentAlerts(ctx context.Context, incidentID string, lim
 				Severity       string            `json:"severity"`
 				Status         string            `json:"status"`
 				TriggerTime    int64             `json:"trigger_time"`
-				DataSourceType string            `json:"data_source_type,omitempty"`
-				DataSourceName string            `json:"data_source_name,omitempty"`
+				IntegrationType string            `json:"integration_type,omitempty"`
+				IntegrationName string            `json:"integration_name,omitempty"`
 				Labels         map[string]string `json:"labels,omitempty"`
 			} `json:"items"`
 		} `json:"data,omitempty"`
@@ -107,8 +107,8 @@ func (c *Client) fetchIncidentAlerts(ctx context.Context, incidentID string, lim
 			Severity:       item.Severity,
 			Status:         item.Status,
 			StartTime:      item.TriggerTime,
-			DataSourceType: item.DataSourceType,
-			DataSourceName: item.DataSourceName,
+			IntegrationType: item.IntegrationType,
+			IntegrationName: item.IntegrationName,
 			Labels:         item.Labels,
 		})
 	}

--- a/pkg/flashduty/enrichment_test.go
+++ b/pkg/flashduty/enrichment_test.go
@@ -9,25 +9,25 @@ import (
 	"time"
 )
 
-// TestAlertPreview_CarriesDataSourceFields asserts the preview struct now
-// carries data_source_type/data_source_name; AI-SRE depends on both to route
+// TestAlertPreview_CarriesIntegrationFields asserts the preview struct now
+// carries integration_type/integration_name; AI-SRE depends on both to route
 // /monit/query/rows calls.
-func TestAlertPreview_CarriesDataSourceFields(t *testing.T) {
+func TestAlertPreview_CarriesIntegrationFields(t *testing.T) {
 	ap := AlertPreview{
-		AlertID:        "a1",
-		Title:          "CPU high",
-		Severity:       "Critical",
-		Status:         "Triggered",
-		StartTime:      1775912219,
-		DataSourceType: "prometheus",
-		DataSourceName: "prom-10.99.1.107",
-		Labels:         map[string]string{"resource": "web-server-01"},
+		AlertID:         "a1",
+		Title:           "CPU high",
+		Severity:        "Critical",
+		Status:          "Triggered",
+		StartTime:       1775912219,
+		IntegrationType: "prometheus",
+		IntegrationName: "prom-10.99.1.107",
+		Labels:          map[string]string{"resource": "web-server-01"},
 	}
-	if ap.DataSourceType != "prometheus" {
-		t.Fatalf("DataSourceType lost: %q", ap.DataSourceType)
+	if ap.IntegrationType != "prometheus" {
+		t.Fatalf("IntegrationType lost: %q", ap.IntegrationType)
 	}
-	if ap.DataSourceName != "prom-10.99.1.107" {
-		t.Fatalf("DataSourceName lost: %q", ap.DataSourceName)
+	if ap.IntegrationName != "prom-10.99.1.107" {
+		t.Fatalf("IntegrationName lost: %q", ap.IntegrationName)
 	}
 }
 
@@ -48,11 +48,11 @@ func newTestClient(t *testing.T, baseURL string) *Client {
 	}
 }
 
-// TestFetchIncidentAlerts_PreservesDataSourceFields asserts that when the
-// upstream /incident/alert/list response carries data_source_type /
-// data_source_name, fetchIncidentAlerts's projection to AlertPreview
+// TestFetchIncidentAlerts_PreservesIntegrationFields asserts that when the
+// upstream /incident/alert/list response carries integration_type /
+// integration_name, fetchIncidentAlerts's projection to AlertPreview
 // keeps both — they are the two fields AI-SRE depends on.
-func TestFetchIncidentAlerts_PreservesDataSourceFields(t *testing.T) {
+func TestFetchIncidentAlerts_PreservesIntegrationFields(t *testing.T) {
 	upstream := `{
       "data": {
         "total": 1,
@@ -62,8 +62,8 @@ func TestFetchIncidentAlerts_PreservesDataSourceFields(t *testing.T) {
           "severity": "Critical",
           "status": "Triggered",
           "trigger_time": 1775912219,
-          "data_source_type": "prometheus",
-          "data_source_name": "prom-10.99.1.107",
+          "integration_type": "prometheus",
+          "integration_name": "prom-10.99.1.107",
           "labels": {"resource":"web-server-01"}
         }]
       }
@@ -83,10 +83,10 @@ func TestFetchIncidentAlerts_PreservesDataSourceFields(t *testing.T) {
 	if total != 1 || len(alerts) != 1 {
 		t.Fatalf("unexpected alerts: total=%d len=%d", total, len(alerts))
 	}
-	if alerts[0].DataSourceType != "prometheus" {
-		t.Fatalf("DataSourceType=%q, want prometheus", alerts[0].DataSourceType)
+	if alerts[0].IntegrationType != "prometheus" {
+		t.Fatalf("IntegrationType=%q, want prometheus", alerts[0].IntegrationType)
 	}
-	if alerts[0].DataSourceName != "prom-10.99.1.107" {
-		t.Fatalf("DataSourceName=%q, want prom-10.99.1.107", alerts[0].DataSourceName)
+	if alerts[0].IntegrationName != "prom-10.99.1.107" {
+		t.Fatalf("IntegrationName=%q, want prom-10.99.1.107", alerts[0].IntegrationName)
 	}
 }

--- a/pkg/flashduty/enrichment_test.go
+++ b/pkg/flashduty/enrichment_test.go
@@ -1,0 +1,92 @@
+package flashduty
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestAlertPreview_CarriesDataSourceFields asserts the preview struct now
+// carries data_source_type/data_source_name; AI-SRE depends on both to route
+// /monit/query/rows calls.
+func TestAlertPreview_CarriesDataSourceFields(t *testing.T) {
+	ap := AlertPreview{
+		AlertID:        "a1",
+		Title:          "CPU high",
+		Severity:       "Critical",
+		Status:         "Triggered",
+		StartTime:      1775912219,
+		DataSourceType: "prometheus",
+		DataSourceName: "prom-10.99.1.107",
+		Labels:         map[string]string{"resource": "web-server-01"},
+	}
+	if ap.DataSourceType != "prometheus" {
+		t.Fatalf("DataSourceType lost: %q", ap.DataSourceType)
+	}
+	if ap.DataSourceName != "prom-10.99.1.107" {
+		t.Fatalf("DataSourceName lost: %q", ap.DataSourceName)
+	}
+}
+
+// newTestClient builds a *Client pointed at baseURL for tests. The production
+// NewClient rejects empty base URL and applies a real app_key check, so we
+// construct the struct directly here — it's package-local.
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	return &Client{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		baseURL:    parsed,
+		appKey:     "test-key",
+		userAgent:  "flashduty-mcp-server-test",
+	}
+}
+
+// TestFetchIncidentAlerts_PreservesDataSourceFields asserts that when the
+// upstream /incident/alert/list response carries data_source_type /
+// data_source_name, fetchIncidentAlerts's projection to AlertPreview
+// keeps both — they are the two fields AI-SRE depends on.
+func TestFetchIncidentAlerts_PreservesDataSourceFields(t *testing.T) {
+	upstream := `{
+      "data": {
+        "total": 1,
+        "items": [{
+          "alert_id": "a1",
+          "title": "CPU high",
+          "severity": "Critical",
+          "status": "Triggered",
+          "trigger_time": 1775912219,
+          "data_source_type": "prometheus",
+          "data_source_name": "prom-10.99.1.107",
+          "labels": {"resource":"web-server-01"}
+        }]
+      }
+    }`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(upstream))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	alerts, total, err := client.fetchIncidentAlerts(context.Background(), "inc-1", 5)
+	if err != nil {
+		t.Fatalf("fetchIncidentAlerts: %v", err)
+	}
+	if total != 1 || len(alerts) != 1 {
+		t.Fatalf("unexpected alerts: total=%d len=%d", total, len(alerts))
+	}
+	if alerts[0].DataSourceType != "prometheus" {
+		t.Fatalf("DataSourceType=%q, want prometheus", alerts[0].DataSourceType)
+	}
+	if alerts[0].DataSourceName != "prom-10.99.1.107" {
+		t.Fatalf("DataSourceName=%q, want prom-10.99.1.107", alerts[0].DataSourceName)
+	}
+}

--- a/pkg/flashduty/types.go
+++ b/pkg/flashduty/types.go
@@ -62,14 +62,14 @@ type TimelineEvent struct {
 
 // AlertPreview represents a preview of an alert
 type AlertPreview struct {
-	AlertID        string            `json:"alert_id" toon:"alert_id"`
-	Title          string            `json:"title" toon:"title"`
-	Severity       string            `json:"severity" toon:"severity"`
-	Status         string            `json:"status" toon:"status"`
-	StartTime      int64             `json:"start_time" toon:"start_time"`
+	AlertID         string            `json:"alert_id" toon:"alert_id"`
+	Title           string            `json:"title" toon:"title"`
+	Severity        string            `json:"severity" toon:"severity"`
+	Status          string            `json:"status" toon:"status"`
+	StartTime       int64             `json:"start_time" toon:"start_time"`
 	IntegrationType string            `json:"integration_type,omitempty" toon:"integration_type,omitempty"`
 	IntegrationName string            `json:"integration_name,omitempty" toon:"integration_name,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty" toon:"labels,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" toon:"labels,omitempty"`
 }
 
 // PersonInfo represents person information from /person/infos API

--- a/pkg/flashduty/types.go
+++ b/pkg/flashduty/types.go
@@ -67,8 +67,8 @@ type AlertPreview struct {
 	Severity       string            `json:"severity" toon:"severity"`
 	Status         string            `json:"status" toon:"status"`
 	StartTime      int64             `json:"start_time" toon:"start_time"`
-	DataSourceType string            `json:"data_source_type,omitempty" toon:"data_source_type,omitempty"`
-	DataSourceName string            `json:"data_source_name,omitempty" toon:"data_source_name,omitempty"`
+	IntegrationType string            `json:"integration_type,omitempty" toon:"integration_type,omitempty"`
+	IntegrationName string            `json:"integration_name,omitempty" toon:"integration_name,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty" toon:"labels,omitempty"`
 }
 

--- a/pkg/flashduty/types.go
+++ b/pkg/flashduty/types.go
@@ -62,12 +62,14 @@ type TimelineEvent struct {
 
 // AlertPreview represents a preview of an alert
 type AlertPreview struct {
-	AlertID   string            `json:"alert_id" toon:"alert_id"`
-	Title     string            `json:"title" toon:"title"`
-	Severity  string            `json:"severity" toon:"severity"`
-	Status    string            `json:"status" toon:"status"`
-	StartTime int64             `json:"start_time" toon:"start_time"`
-	Labels    map[string]string `json:"labels,omitempty" toon:"labels,omitempty"`
+	AlertID        string            `json:"alert_id" toon:"alert_id"`
+	Title          string            `json:"title" toon:"title"`
+	Severity       string            `json:"severity" toon:"severity"`
+	Status         string            `json:"status" toon:"status"`
+	StartTime      int64             `json:"start_time" toon:"start_time"`
+	DataSourceType string            `json:"data_source_type,omitempty" toon:"data_source_type,omitempty"`
+	DataSourceName string            `json:"data_source_name,omitempty" toon:"data_source_name,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty" toon:"labels,omitempty"`
 }
 
 // PersonInfo represents person information from /person/infos API


### PR DESCRIPTION
## Summary

Extend the `AlertPreview` struct returned by `query_incident_alerts` with the alert's integration metadata so AI-SRE can drill from an incident down to the backing datasource:

- `integration_type` — e.g. `prometheus`, `victorialogs`, `mysql`
- `integration_name` — concrete datasource name registered in monit-webapi

These are the two fields the `monit-query` skill reads to construct `POST /monit/query/rows`. The upstream Alert struct already carries both (`fc-event/structs/alert.go`); this PR is a pass-through projection.

Naming follows the non-deprecated `Integration.*` convention from fc-event (the matching `DataSource.*` pair is marked Deprecated in structs/alert.go).

## Test plan

- [x] `TestAlertPreview_CarriesIntegrationFields` — struct round-trip
- [x] `TestFetchIncidentAlerts_PreservesIntegrationFields` — httptest.Server projection check
- [x] `go test ./...` clean on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)