### PR TITLE
feat: rename time params to since/until and add query_alerts tools

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -420,8 +420,8 @@ func TestQueryIncidents(t *testing.T) {
 
 	t.Log("Querying incidents from the last 7 days...")
 	responseText := callTool(t, mcpClient, "query_incidents", map[string]any{
-		"start_time":     strconv.FormatInt(startTime, 10),
-		"end_time":       strconv.FormatInt(now, 10),
+		"since":          strconv.FormatInt(startTime, 10),
+		"until":          strconv.FormatInt(now, 10),
 		"limit":          10,
 		"include_alerts": false,
 	})
@@ -532,9 +532,9 @@ func TestQueryChanges(t *testing.T) {
 
 	t.Log("Querying changes from the last 7 days...")
 	responseText := callTool(t, mcpClient, "query_changes", map[string]any{
-		"start_time": strconv.FormatInt(startTime, 10),
-		"end_time":   strconv.FormatInt(now, 10),
-		"limit":      10,
+		"since": strconv.FormatInt(startTime, 10),
+		"until": strconv.FormatInt(now, 10),
+		"limit": 10,
 	})
 
 	var result struct {

--- a/e2e/fixes_validation_test.go
+++ b/e2e/fixes_validation_test.go
@@ -23,8 +23,8 @@ func TestQueryIncidentsChannelFilter(t *testing.T) {
 	startTime := now - 30*24*60*60
 
 	allText := callTool(t, mcpClient, "query_incidents", map[string]any{
-		"start_time":     strconv.FormatInt(startTime, 10),
-		"end_time":       strconv.FormatInt(now, 10),
+		"since":          strconv.FormatInt(startTime, 10),
+		"until":          strconv.FormatInt(now, 10),
 		"limit":          100,
 		"include_alerts": false,
 	})
@@ -59,8 +59,8 @@ func TestQueryIncidentsChannelFilter(t *testing.T) {
 		target, maxCount, otherChannelCount)
 
 	filteredText := callTool(t, mcpClient, "query_incidents", map[string]any{
-		"start_time":     strconv.FormatInt(startTime, 10),
-		"end_time":       strconv.FormatInt(now, 10),
+		"since":          strconv.FormatInt(startTime, 10),
+		"until":          strconv.FormatInt(now, 10),
 		"limit":          100,
 		"include_alerts": false,
 		"channel_ids":    strconv.FormatInt(target, 10),

--- a/pkg/flashduty/alerts.go
+++ b/pkg/flashduty/alerts.go
@@ -23,8 +23,8 @@ func QueryAlerts(getClient GetFlashdutyClientFn, t translations.TranslationHelpe
 				Title:        t("TOOL_QUERY_ALERTS_USER_TITLE", "Query alerts"),
 				ReadOnlyHint: ToBoolPtr(true),
 			}),
-			mcp.WithString("since", mcp.Required(), mcp.Description("Lower bound of the query window. Accepts: relative duration like \"24h\", \"7d\", \"30m\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Required.")),
-			mcp.WithString("until", mcp.Required(), mcp.Description("Upper bound of the query window. Same formats as since, plus future durations like \"+24h\". Use \"now\" for current time. Required.")),
+			WithSince(mcp.Required()),
+			WithUntil(mcp.Required()),
 			mcp.WithString("severity", mcp.Description("Filter by alert severity."), mcp.Enum("Info", "Warning", "Critical")),
 			mcp.WithBoolean("is_active", mcp.Description("If true, only return alerts that are currently active (Triggered or Processing). If false, only inactive (Closed). If omitted, returns all.")),
 			mcp.WithString("channel_ids", mcp.Description("Comma-separated collaboration space IDs to filter by.")),
@@ -50,8 +50,8 @@ func QueryAlerts(getClient GetFlashdutyClientFn, t translations.TranslationHelpe
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("invalid until: %v", err)), nil
 			}
-			if startTime == 0 || endTime == 0 {
-				return mcp.NewToolResultError("Both since and until are required"), nil
+			if err := validateTimeWindow(startTime, endTime); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
 			}
 
 			severity, _ := OptionalParam[string](request, "severity")

--- a/pkg/flashduty/alerts.go
+++ b/pkg/flashduty/alerts.go
@@ -1,0 +1,161 @@
+package flashduty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/flashcatcloud/flashduty-sdk"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/flashcatcloud/flashduty-mcp-server/internal/timeutil"
+	"github.com/flashcatcloud/flashduty-mcp-server/pkg/translations"
+)
+
+const queryAlertsDescription = `Query alerts by time range and filters. Returns enriched data with channel/integration names. Useful for finding active or historical alerts that fed into incidents.`
+
+// QueryAlerts creates a tool to query alerts with enriched data.
+func QueryAlerts(getClient GetFlashdutyClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("query_alerts",
+			mcp.WithDescription(t("TOOL_QUERY_ALERTS_DESCRIPTION", queryAlertsDescription)),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_QUERY_ALERTS_USER_TITLE", "Query alerts"),
+				ReadOnlyHint: ToBoolPtr(true),
+			}),
+			mcp.WithString("since", mcp.Required(), mcp.Description("Lower bound of the query window. Accepts: relative duration like \"24h\", \"7d\", \"30m\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Required.")),
+			mcp.WithString("until", mcp.Required(), mcp.Description("Upper bound of the query window. Same formats as since, plus future durations like \"+24h\". Use \"now\" for current time. Required.")),
+			mcp.WithString("severity", mcp.Description("Filter by alert severity."), mcp.Enum("Info", "Warning", "Critical")),
+			mcp.WithBoolean("is_active", mcp.Description("If true, only return alerts that are currently active (Triggered or Processing). If false, only inactive (Closed). If omitted, returns all.")),
+			mcp.WithString("channel_ids", mcp.Description("Comma-separated collaboration space IDs to filter by.")),
+			mcp.WithString("integration_ids", mcp.Description("Comma-separated integration IDs to filter by.")),
+			mcp.WithString("alert_keys", mcp.Description("Comma-separated alert dedup keys for direct lookup.")),
+			mcp.WithBoolean("ever_muted", mcp.Description("If true, only return alerts that were ever muted by a routing rule.")),
+			mcp.WithString("title", mcp.Description("Keyword search in alert title.")),
+			mcp.WithString("labels", mcp.Description("JSON object of label key-value pairs to match. Format: {\"resource\":\"web-01\",\"region\":\"us-west\"}.")),
+			mcp.WithNumber("limit", mcp.Description("Maximum number of results to return."), mcp.DefaultNumber(20), mcp.Min(1), mcp.Max(100)),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			ctx, client, err := getClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Flashduty client: %w", err)
+			}
+
+			args := request.GetArguments()
+
+			startTime, err := timeutil.ParseAny(args["since"])
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("invalid since: %v", err)), nil
+			}
+			endTime, err := timeutil.ParseAny(args["until"])
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("invalid until: %v", err)), nil
+			}
+			if startTime == 0 || endTime == 0 {
+				return mcp.NewToolResultError("Both since and until are required"), nil
+			}
+
+			severity, _ := OptionalParam[string](request, "severity")
+			channelIdsStr, _ := OptionalParam[string](request, "channel_ids")
+			integrationIdsStr, _ := OptionalParam[string](request, "integration_ids")
+			alertKeysStr, _ := OptionalParam[string](request, "alert_keys")
+			title, _ := OptionalParam[string](request, "title")
+			labelsStr, _ := OptionalParam[string](request, "labels")
+			limit, _ := OptionalInt(request, "limit")
+			if limit <= 0 {
+				limit = defaultQueryLimit
+			}
+
+			input := &sdk.ListAlertsInput{
+				StartTime:     startTime,
+				EndTime:       endTime,
+				AlertSeverity: severity,
+				Title:         title,
+				Limit:         limit,
+			}
+
+			if v, ok := args["is_active"].(bool); ok {
+				input.IsActive = &v
+			}
+			if v, ok := args["ever_muted"].(bool); ok {
+				input.EverMuted = &v
+			}
+
+			if channelIdsStr != "" {
+				ids := parseCommaSeparatedInts(channelIdsStr)
+				if len(ids) == 0 {
+					return mcp.NewToolResultError("channel_ids must contain at least one valid ID when specified"), nil
+				}
+				input.ChannelIDs = make([]int64, len(ids))
+				for i, id := range ids {
+					input.ChannelIDs[i] = int64(id)
+				}
+			}
+			if integrationIdsStr != "" {
+				ids := parseCommaSeparatedInts(integrationIdsStr)
+				if len(ids) == 0 {
+					return mcp.NewToolResultError("integration_ids must contain at least one valid ID when specified"), nil
+				}
+				input.IntegrationIDs = make([]int64, len(ids))
+				for i, id := range ids {
+					input.IntegrationIDs[i] = int64(id)
+				}
+			}
+			if alertKeysStr != "" {
+				input.AlertKeys = parseCommaSeparatedStrings(alertKeysStr)
+			}
+			if labelsStr != "" {
+				labels := map[string]string{}
+				if err := json.Unmarshal([]byte(labelsStr), &labels); err != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("invalid labels JSON: %v", err)), nil
+				}
+				if len(labels) > 0 {
+					input.Labels = labels
+				}
+			}
+
+			output, err := client.ListAlerts(ctx, input)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Unable to retrieve alerts: %v", err)), nil
+			}
+
+			return MarshalResult(map[string]any{
+				"alerts":           output.Alerts,
+				"total":            output.Total,
+				"has_next_page":    output.HasNextPage,
+				"search_after_ctx": output.SearchAfterCtx,
+			}), nil
+		}
+}
+
+const queryAlertEventsDescription = `Query raw events for a single alert. Returns the upstream event stream that produced the alert (e.g. each individual Prometheus firing).`
+
+// QueryAlertEvents creates a tool to query raw events of a single alert.
+func QueryAlertEvents(getClient GetFlashdutyClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("query_alert_events",
+			mcp.WithDescription(t("TOOL_QUERY_ALERT_EVENTS_DESCRIPTION", queryAlertEventsDescription)),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_QUERY_ALERT_EVENTS_USER_TITLE", "Query alert events"),
+				ReadOnlyHint: ToBoolPtr(true),
+			}),
+			mcp.WithString("alert_id", mcp.Required(), mcp.Description("Alert ID whose raw events should be returned.")),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			ctx, client, err := getClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Flashduty client: %w", err)
+			}
+
+			alertID, err := RequiredParam[string](request, "alert_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			output, err := client.ListAlertEvents(ctx, &sdk.ListAlertEventsInput{AlertID: alertID})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Unable to retrieve alert events: %v", err)), nil
+			}
+
+			return MarshalResult(map[string]any{
+				"alert_events": output.AlertEvents,
+			}), nil
+		}
+}

--- a/pkg/flashduty/changes.go
+++ b/pkg/flashduty/changes.go
@@ -24,8 +24,8 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 			}),
 			mcp.WithString("change_ids", mcp.Description("Comma-separated change IDs for direct lookup.")),
 			mcp.WithString("channel_ids", mcp.Description("Comma-separated collaboration space IDs to filter by. Backend expects an array — singular channel_id is silently ignored.")),
-			mcp.WithString("start_time", mcp.Description("Query start time. Accepts: relative duration like \"1h\", \"24h\", \"7d\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Defaults to 1 hour ago. Max range: 31 days.")),
-			mcp.WithString("end_time", mcp.Description("Query end time. Same formats as start_time, plus future durations like \"+24h\". Defaults to \"now\".")),
+			mcp.WithString("since", mcp.Description("Lower bound of the query window. Accepts: relative duration like \"1h\", \"24h\", \"7d\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Defaults to 1 hour ago. Max range: 31 days.")),
+			mcp.WithString("until", mcp.Description("Upper bound of the query window. Same formats as since, plus future durations like \"+24h\". Defaults to \"now\".")),
 			mcp.WithString("type", mcp.Description("Filter by change type.")),
 			mcp.WithNumber("limit", mcp.Description("Maximum number of results to return."), mcp.DefaultNumber(20), mcp.Min(1), mcp.Max(100)),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -44,13 +44,13 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 				limit = 20
 			}
 
-			startTime, err := timeutil.ParseAny(args["start_time"])
+			startTime, err := timeutil.ParseAny(args["since"])
 			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid start_time: %v", err)), nil
+				return mcp.NewToolResultError(fmt.Sprintf("invalid since: %v", err)), nil
 			}
-			endTime, err := timeutil.ParseAny(args["end_time"])
+			endTime, err := timeutil.ParseAny(args["until"])
 			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid end_time: %v", err)), nil
+				return mcp.NewToolResultError(fmt.Sprintf("invalid until: %v", err)), nil
 			}
 
 			input := &sdk.ListChangesInput{

--- a/pkg/flashduty/changes.go
+++ b/pkg/flashduty/changes.go
@@ -3,6 +3,7 @@ package flashduty
 import (
 	"context"
 	"fmt"
+	"time"
 
 	sdk "github.com/flashcatcloud/flashduty-sdk"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -24,8 +25,8 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 			}),
 			mcp.WithString("change_ids", mcp.Description("Comma-separated change IDs for direct lookup.")),
 			mcp.WithString("channel_ids", mcp.Description("Comma-separated collaboration space IDs to filter by. Backend expects an array — singular channel_id is silently ignored.")),
-			mcp.WithString("since", mcp.Description("Lower bound of the query window. Accepts: relative duration like \"1h\", \"24h\", \"7d\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Defaults to 1 hour ago. Max range: 31 days.")),
-			mcp.WithString("until", mcp.Description("Upper bound of the query window. Same formats as since, plus future durations like \"+24h\". Defaults to \"now\".")),
+			WithSince(),
+			WithUntil(),
 			mcp.WithString("type", mcp.Description("Filter by change type.")),
 			mcp.WithNumber("limit", mcp.Description("Maximum number of results to return."), mcp.DefaultNumber(20), mcp.Min(1), mcp.Max(100)),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -51,6 +52,17 @@ func QueryChanges(getClient GetFlashdutyClientFn, t translations.TranslationHelp
 			endTime, err := timeutil.ParseAny(args["until"])
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("invalid until: %v", err)), nil
+			}
+			// Honor the "defaults to last hour" contract advertised in the old
+			// description: backend rejects 0/0, so we have to apply it ourselves.
+			if endTime == 0 {
+				endTime = time.Now().Unix()
+			}
+			if startTime == 0 {
+				startTime = endTime - 3600
+			}
+			if err := validateTimeWindow(startTime, endTime); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
 			}
 
 			input := &sdk.ListChangesInput{

--- a/pkg/flashduty/incidents.go
+++ b/pkg/flashduty/incidents.go
@@ -30,8 +30,8 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 			mcp.WithString("progress", mcp.Description("Filter by status. Valid values: Triggered, Processing, Closed. Comma-separated for multiple."), mcp.Enum("Triggered", "Processing", "Closed", "Triggered,Processing", "Processing,Closed", "Triggered,Closed", "Triggered,Processing,Closed")),
 			mcp.WithString("severity", mcp.Description("Filter by severity level. Valid values: Info, Warning, Critical."), mcp.Enum("Info", "Warning", "Critical")),
 			mcp.WithString("channel_ids", mcp.Description("Comma-separated collaboration space IDs to filter by. Backend expects an array — singular channel_id is silently ignored.")),
-			mcp.WithString("start_time", mcp.Description("Query start time. Accepts: relative duration like \"24h\", \"7d\", \"30m\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Required if no incident_ids. Max range: 31 days.")),
-			mcp.WithString("end_time", mcp.Description("Query end time. Same formats as start_time, plus future durations like \"+24h\", \"+7d\". Defaults to \"now\" when omitted. Required if no incident_ids.")),
+			mcp.WithString("since", mcp.Description("Lower bound of the query window. Accepts: relative duration like \"24h\", \"7d\", \"30m\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Required if no incident_ids. Max range: 31 days.")),
+			mcp.WithString("until", mcp.Description("Upper bound of the query window. Same formats as since, plus future durations like \"+24h\", \"+7d\". Defaults to \"now\" when omitted. Required if no incident_ids.")),
 			mcp.WithString("title", mcp.Description("Keyword search in incident title.")),
 			mcp.WithNumber("limit", mcp.Description("Maximum number of results to return."), mcp.DefaultNumber(20), mcp.Min(1), mcp.Max(100)),
 			mcp.WithBoolean("include_alerts", mcp.Description("Whether to include alerts preview (first 20 alerts with total count)."), mcp.DefaultBool(true)),
@@ -50,13 +50,13 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 			title, _ := OptionalParam[string](request, "title")
 			limit, _ := OptionalInt(request, "limit")
 
-			startTime, err := timeutil.ParseAny(args["start_time"])
+			startTime, err := timeutil.ParseAny(args["since"])
 			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid start_time: %v", err)), nil
+				return mcp.NewToolResultError(fmt.Sprintf("invalid since: %v", err)), nil
 			}
-			endTime, err := timeutil.ParseAny(args["end_time"])
+			endTime, err := timeutil.ParseAny(args["until"])
 			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("invalid end_time: %v", err)), nil
+				return mcp.NewToolResultError(fmt.Sprintf("invalid until: %v", err)), nil
 			}
 
 			includeAlerts := true
@@ -96,7 +96,7 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 				}
 				input.IncidentIDs = incidentIDs
 			} else if startTime == 0 || endTime == 0 {
-				return mcp.NewToolResultError("Both start_time and end_time are required for time-based queries"), nil
+				return mcp.NewToolResultError("Both since and until are required for time-based queries"), nil
 			}
 
 			output, err := client.ListIncidents(ctx, input)

--- a/pkg/flashduty/incidents.go
+++ b/pkg/flashduty/incidents.go
@@ -30,8 +30,8 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 			mcp.WithString("progress", mcp.Description("Filter by status. Valid values: Triggered, Processing, Closed. Comma-separated for multiple."), mcp.Enum("Triggered", "Processing", "Closed", "Triggered,Processing", "Processing,Closed", "Triggered,Closed", "Triggered,Processing,Closed")),
 			mcp.WithString("severity", mcp.Description("Filter by severity level. Valid values: Info, Warning, Critical."), mcp.Enum("Info", "Warning", "Critical")),
 			mcp.WithString("channel_ids", mcp.Description("Comma-separated collaboration space IDs to filter by. Backend expects an array — singular channel_id is silently ignored.")),
-			mcp.WithString("since", mcp.Description("Lower bound of the query window. Accepts: relative duration like \"24h\", \"7d\", \"30m\" (interpreted as now minus duration); absolute date \"2026-04-01\"; datetime \"2026-04-01 10:00:00\"; unix seconds \"1712000000\"; or \"now\". Required if no incident_ids. Max range: 31 days.")),
-			mcp.WithString("until", mcp.Description("Upper bound of the query window. Same formats as since, plus future durations like \"+24h\", \"+7d\". Defaults to \"now\" when omitted. Required if no incident_ids.")),
+			WithSince(),
+			WithUntil(),
 			mcp.WithString("title", mcp.Description("Keyword search in incident title.")),
 			mcp.WithNumber("limit", mcp.Description("Maximum number of results to return."), mcp.DefaultNumber(20), mcp.Min(1), mcp.Max(100)),
 			mcp.WithBoolean("include_alerts", mcp.Description("Whether to include alerts preview (first 20 alerts with total count)."), mcp.DefaultBool(true)),
@@ -95,8 +95,8 @@ func QueryIncidents(getClient GetFlashdutyClientFn, t translations.TranslationHe
 					return mcp.NewToolResultError("incident_ids must contain at least one valid ID when specified"), nil
 				}
 				input.IncidentIDs = incidentIDs
-			} else if startTime == 0 || endTime == 0 {
-				return mcp.NewToolResultError("Both since and until are required for time-based queries"), nil
+			} else if err := validateTimeWindow(startTime, endTime); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
 			}
 
 			output, err := client.ListIncidents(ctx, input)

--- a/pkg/flashduty/time_args.go
+++ b/pkg/flashduty/time_args.go
@@ -1,0 +1,62 @@
+package flashduty
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// MaxTimeWindow is the backend's hard cap on (until-since) for incident/alert/change
+// queries. Exceeding it produces a 400 from the API; we mirror the cap client-side
+// so the LLM gets a guided error before the round-trip.
+const MaxTimeWindow = 31 * 24 * time.Hour
+
+// SinceDescription / UntilDescription are reused across query_incidents,
+// query_alerts, and query_changes. The wording is tuned for LLM callers that
+// otherwise pick absolute dates from stale training data and silently query
+// the wrong year — see the three failure modes documented at
+// https://github.com/flashcatcloud/flashduty-mcp-server/pull/50.
+const (
+	SinceDescription = "Lower bound of the query window. " +
+		"PREFER relative durations like \"24h\", \"7d\", \"30m\" — they are anchored " +
+		"to server time and immune to your training-data cutoff. " +
+		"Use absolute dates (\"2026-04-01\" or \"2026-04-01 10:00:00\") ONLY when " +
+		"the user explicitly asked for a specific calendar date; double-check the " +
+		"year, since picking the wrong year returns silently incorrect data. " +
+		"Also accepts unix seconds (\"1712000000\") and \"now\". " +
+		"Max window (until - since): 31 days. Data older than ~90 days may have been purged."
+
+	UntilDescription = "Upper bound of the query window. Same formats as `since`, plus " +
+		"future durations like \"+24h\", \"+7d\". Defaults to \"now\" when omitted. " +
+		"Must be greater than `since` and within 31 days of it."
+)
+
+// WithSince / WithUntil are convenience wrappers that apply the canonical descriptions.
+func WithSince(opts ...mcp.PropertyOption) mcp.ToolOption {
+	return mcp.WithString("since", append([]mcp.PropertyOption{mcp.Description(SinceDescription)}, opts...)...)
+}
+
+func WithUntil(opts ...mcp.PropertyOption) mcp.ToolOption {
+	return mcp.WithString("until", append([]mcp.PropertyOption{mcp.Description(UntilDescription)}, opts...)...)
+}
+
+// validateTimeWindow enforces the same constraints the backend would, but with
+// LLM-actionable error messages. since and until are unix seconds; both must be
+// non-zero. Returns nil when the window is valid.
+func validateTimeWindow(since, until int64) error {
+	if since <= 0 || until <= 0 {
+		return fmt.Errorf("both since and until are required")
+	}
+	if since >= until {
+		return fmt.Errorf("since (%d) must be earlier than until (%d); did you swap them?", since, until)
+	}
+	if window := time.Duration(until-since) * time.Second; window > MaxTimeWindow {
+		return fmt.Errorf(
+			"window of %s exceeds the 31-day max; split into smaller chunks (e.g. 7d at a time) "+
+				"or pass *_ids for direct lookup",
+			window.Round(time.Hour),
+		)
+	}
+	return nil
+}

--- a/pkg/flashduty/tools.go
+++ b/pkg/flashduty/tools.go
@@ -6,7 +6,7 @@ import (
 )
 
 // DefaultTools is the default list of enabled Flashduty toolsets
-var DefaultTools = []string{"incidents", "changes", "status_page", "users", "channels", "fields", "templates"}
+var DefaultTools = []string{"incidents", "alerts", "changes", "status_page", "users", "channels", "fields", "templates"}
 
 // DefaultToolsetGroup returns the default toolset group for Flashduty
 func DefaultToolsetGroup(getClient GetFlashdutyClientFn, readOnly bool, t translations.TranslationHelperFunc) *toolsets.ToolsetGroup {
@@ -27,6 +27,14 @@ func DefaultToolsetGroup(getClient GetFlashdutyClientFn, readOnly bool, t transl
 			toolsets.NewServerTool(CloseIncident(getClient, t)),
 		)
 	group.AddToolset(incidents)
+
+	// Alerts toolset (2 tools)
+	alerts := toolsets.NewToolset("alerts", "Alert query tools").
+		AddReadTools(
+			toolsets.NewServerTool(QueryAlerts(getClient, t)),
+			toolsets.NewServerTool(QueryAlertEvents(getClient, t)),
+		)
+	group.AddToolset(alerts)
 
 	// Changes toolset (1 tool)
 	changes := toolsets.NewToolset("changes", "Change record query tools").


### PR DESCRIPTION
## Summary

Two related changes that follow up on PR #40's time-parameter work:

### 1. Rename `start_time`/`end_time` → `since`/`until`

After #40, `query_incidents` and `query_changes` accept LLM-friendly time strings (`24h`, `7d`, `+24h`, `2026-04-01`, `now`, …). The legacy parameter names — `start_time`/`end_time` — still read as absolute timestamps, which discouraged the LLM from passing the very relative-duration strings the schema now supports. Rename to `since`/`until` to match `flashduty-cli`'s `--since`/`--until` flags and signal the dual nature.

`create_change_timeline` keeps its `at` parameter — a single point-in-time, no pair semantics.

### 2. Add `alerts` toolset

`flashduty-sdk` v0.8.0 already has `ListAlerts` and `ListAlertEvents`, but they weren't surfaced as MCP tools. This PR adds them:

- **`query_alerts`** — list alerts by time window with filters (severity, is_active, channel_ids, integration_ids, alert_keys, ever_muted, title, labels). Uses `since`/`until`.
- **`query_alert_events`** — get raw upstream events for a single alert by alert_id.

Registered as a new `alerts` toolset between `incidents` and `changes`.

## Test plan

- [x] `make fmt` clean
- [x] `make lint` 0 issues
- [x] `go test -short ./...` passes
- [x] E2E `TestQueryIncidents`, `TestQueryIncidentsChannelFilter`, `TestQueryChanges` pass with renamed params (against local instance)
- [x] Smoke-test `query_alerts` over stdio: `since=24h until=now limit=3` returns 3 enriched alerts with `has_next_page=true`
- [ ] Smoke-test `query_alert_events` against a known alert_id

## Breaking change

`since`/`until` is a breaking rename for callers of `query_incidents` and `query_changes`. `timeutil.ParseAny` absorbs the value type but the parameter *name* changed. LLM clients adapt automatically (re-fetch tool list); programmatic callers (terraform, scripts) need a one-line update.

🤖 Generated with [Claude Code](https://claude.ai/code)