### PR TITLE
chore: bump flashduty-sdk for alerts_total regression fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/bluele/gcache v0.0.2
-	github.com/flashcatcloud/flashduty-sdk v0.8.1-0.20260510062220-7b45b9d90798
+	github.com/flashcatcloud/flashduty-sdk v0.8.1-0.20260510070250-0340ac6a5a33
 	github.com/google/go-github/v72 v72.0.0
 	github.com/josephburnett/jd v1.9.2
 	github.com/mark3labs/mcp-go v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/flashcatcloud/flashduty-sdk v0.8.1-0.20260510062220-7b45b9d90798 h1:FK1Ueq3ROSxCTTKX8rq0m5x3JcbAsoTnLsty5klbMEs=
-github.com/flashcatcloud/flashduty-sdk v0.8.1-0.20260510062220-7b45b9d90798/go.mod h1:dG4eJfdZaj4jNBMwEexbfK/3PmcIMhNeJ88L/DcZzUY=
+github.com/flashcatcloud/flashduty-sdk v0.8.1-0.20260510070250-0340ac6a5a33 h1:HnB++VulEnF+oIsNwKK8QBv4CCdG+ztdFKLScI4bXlc=
+github.com/flashcatcloud/flashduty-sdk v0.8.1-0.20260510070250-0340ac6a5a33/go.mod h1:dG4eJfdZaj4jNBMwEexbfK/3PmcIMhNeJ88L/DcZzUY=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
## Summary

- Bumps `flashduty-sdk` to `0340ac6` (includes SDK PR #7 + #8).
- Restores `alerts_total` in `query_incidents` responses, which silently dropped to 0 in v0.9.8.

## Why

In v0.9.8 we removed `include_alerts` from `query_incidents` to shrink LLM context (30 KB → 17 KB). The intent was to keep `alerts_total` as a cheap volume gauge so the LLM knows whether to drill into `query_incident_alerts`. But the SDK only populated `AlertsTotal` inside its `if input.IncludeAlerts` block — so every incident silently reported `alerts_total: 0`, defeating the field's purpose.

SDK PR #8 fixes this by always populating `AlertsTotal` (uses `limit=1` per incident, items discarded). `AlertsPreview` semantics are unchanged.

## Test plan
- [x] `go test -race ./...` passes
- [x] `make build` clean
- [ ] After merge: tag v0.9.9 and verify `query_incidents` returns non-zero `alerts_total` against a live tenant