### PR TITLE
docs: point to flashduty-cli for full open-API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ English | [中文](README_zh.md)
 
 The Flashduty MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that provides seamless integration with Flashduty APIs, enabling advanced incident management and automation capabilities for developers and tools.
 
+> [!NOTE]
+> **Curated by design.** This server exposes a small, task-oriented toolset rather than mirroring the full Flashduty Open API — large 1:1 tool catalogs bloat model context and degrade tool selection. For 1:1 coverage of every open API operation, use the [Flashduty CLI](https://github.com/flashcatcloud/flashduty-cli); AI agents with shell access can drive it directly.
+
 ### Use Cases
 
 - Automating Flashduty workflows and processes.

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,6 +4,9 @@
 
 Flashduty MCP Server 是一个基于 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) 的服务，提供与 Flashduty API 的无缝对接，帮助开发者和工具实现智能化的故障管理与自动化运维。
 
+> [!NOTE]
+> **刻意保持精简。**本服务只提供一小组面向任务的工具，而非 1:1 镜像全部 Flashduty 开放 API——庞大的工具清单会挤占模型上下文并降低工具选择准确率。如需完整覆盖全部开放 API，请使用 [Flashduty CLI](https://github.com/flashcatcloud/flashduty-cli)，具备 shell 能力的 AI Agent 可直接调用它。
+
 ### 应用场景
 
 - 自动化 Flashduty 工作流程

--- a/internal/flashduty/server.go
+++ b/internal/flashduty/server.go
@@ -44,6 +44,10 @@ type FlashdutyConfig struct {
 	Translator translations.TranslationHelperFunc
 }
 
+// serverInstructions is the default text returned to clients in the
+// initialize response; see cfg.Translator for how it can be overridden.
+const serverInstructions = "This server provides a curated, task-oriented toolset for Flashduty; it intentionally does not mirror the full Flashduty Open API. For operations not covered by these tools, use the Flashduty CLI (https://github.com/flashcatcloud/flashduty-cli), which covers the open API 1:1 — agents with shell access can drive it directly."
+
 func NewMCPServer(cfg FlashdutyConfig) (*server.MCPServer, error) {
 	// When a client send an initialize request, update the user agent to include the client info.
 	beforeInit := func(ctx context.Context, _ any, message *mcp.InitializeRequest) {
@@ -113,7 +117,7 @@ func NewMCPServer(cfg FlashdutyConfig) (*server.MCPServer, error) {
 		},
 	}
 
-	flashdutyServer := server.NewMCPServer("flashduty-mcp-server", cfg.Version, server.WithHooks(hooks))
+	flashdutyServer := server.NewMCPServer("flashduty-mcp-server", cfg.Version, server.WithHooks(hooks), server.WithInstructions(cfg.Translator("SERVER_INSTRUCTIONS", serverInstructions)))
 
 	getClientFn := func(ctx context.Context) (context.Context, *flashduty.Clients, error) {
 		return getClient(ctx, cfg, cfg.Version)

--- a/pkg/flashduty/format.go
+++ b/pkg/flashduty/format.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	toon "github.com/toon-format/toon-go"
-
 	"github.com/mark3labs/mcp-go/mcp"
+	toon "github.com/toon-format/toon-go"
 )
 
 // OutputFormat defines the serialization format for tool results.


### PR DESCRIPTION
The MCP server intentionally ships a curated, task-oriented toolset rather than mirroring all open-API operations (large 1:1 tool catalogs bloat model context and degrade tool selection). This PR makes that design explicit instead of leaving it as an apparent gap:

- **Server instructions** (`initialize` response): connected agents are told the toolset is curated and that full 1:1 open-API coverage lives in [flashduty-cli](https://github.com/flashcatcloud/flashduty-cli). Overridable via `GITHUB_MCP_SERVER_INSTRUCTIONS`, same translator path as all other client-facing strings.
- **README.md / README_zh.md**: matching note after the intro.
- `pkg/flashduty/format.go`: gci import reorder from `make fmt` (pre-existing drift).

Verified: `make test` + `make build` green; stdio `initialize` returns the instructions, and the env override works end-to-end.